### PR TITLE
Ensure io.jsonwebtoken:jwt-{impl,jackson} deps are in uberjar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.4.0</version>
+                    <version>3.4.1</version>
                     <configuration>
                         <minimizeJar>true</minimizeJar>
                         <shadedArtifactAttached>true</shadedArtifactAttached>
@@ -161,6 +161,20 @@
                         </transformers>
 
                         <filters>
+                            <!-- jjwt-impl and jjwt-jackson have to be explicitly enabled,
+                                 because there is no compiler-visible dependency  -->
+                            <filter>
+                                <artifact>io.jsonwebtoken:jjwt-impl</artifact>
+                                <includes>
+                                    <include>**</include>
+                                </includes>
+                            </filter>
+                            <filter>
+                                <artifact>io.jsonwebtoken:jjwt-jackson</artifact>
+                                <includes>
+                                    <include>**</include>
+                                </includes>
+                            </filter>
                             <filter>
                                 <artifact>*:*</artifact>
                                 <excludes>
@@ -169,6 +183,7 @@
                                     <exclude>**/linux/**</exclude>
                                     <exclude>**/win32/**</exclude>
                                     <exclude>**/module-info.class</exclude>
+                                    <exclude>.netbeans_automatic_build</exclude>
 
                                     <exclude>META-INF/DEPENDENCIES</exclude>
                                     <exclude>META-INF/MANIFEST.MF</exclude>


### PR DESCRIPTION
Packages io.jsonwebtoken:jwt-{impl,jackson} are necessary to perform service account key based authentication.
Currently the uberjar build excludes those packages, as there are no compile-time dependencies on them.
The fix forces those deps to be included in the uberjar