### PR TITLE
[Bug]: Fix parseSingleQuotes

### DIFF
--- a/jdbc/src/main/java/tech/ydb/jdbc/query/JdbcQueryLexer.java
+++ b/jdbc/src/main/java/tech/ydb/jdbc/query/JdbcQueryLexer.java
@@ -126,20 +126,11 @@ public class JdbcQueryLexer {
     }
 
     private static int parseSingleQuotes(final char[] query, int offset) {
-        // treat backslashes as escape characters
-        while (++offset < query.length) {
-            switch (query[offset]) {
-                case '\\':
-                    ++offset;
-                    break;
-                case '\'':
-                    return offset;
-                default:
-                    break;
-            }
+        while (++offset < query.length && query[offset] != '\'') {
+            // do nothing
         }
 
-        return query.length;
+        return offset;
     }
 
     private static int parseDoubleQuotes(final char[] query, int offset) {

--- a/jdbc/src/test/java/tech/ydb/jdbc/query/QueryLexerTest.java
+++ b/jdbc/src/test/java/tech/ydb/jdbc/query/QueryLexerTest.java
@@ -162,4 +162,17 @@ public class QueryLexerTest {
         ));
     }
 
+    @Test
+    public void detectJdbcParamsTest() throws SQLException {
+        YdbQueryOptions opts = new YdbQueryOptions(true, true, false, false, false, null);
+
+        YdbQueryBuilder queryBuilder = new YdbQueryBuilder("select b1_0.id,b1_0.author_id,b1_0.isbn10,b1_0.publication_date,b1_0.title" +
+                " from books b1_0 where b1_0.title like ? escape '\\' " +
+                "order by b1_0.publication_date limit ? offset ?]", null);
+
+        JdbcQueryLexer.buildQuery(queryBuilder, opts);
+
+        Assertions.assertEquals(3, queryBuilder.getIndexedArgs().size());
+        Assertions.assertEquals(QueryType.DATA_QUERY, queryBuilder.getQueryType());
+    }
 }


### PR DESCRIPTION
```
    private static int parseSingleQuotes(final char[] query, int offset) {
        while (++offset < query.length && query[offset] != '\'') {
            // do nothing
        }

        return offset;
    }

    private static int parseDoubleQuotes(final char[] query, int offset) {
        while (++offset < query.length && query[offset] != '"') {
            // do nothing
        }
        return offset;
    }
```

These should be equivalent methods. The escape character is missing from the source string.