### PR TITLE
Rewrite options to control query special modes

### DIFF
--- a/jdbc/src/main/java/tech/ydb/jdbc/query/YdbQuery.java
+++ b/jdbc/src/main/java/tech/ydb/jdbc/query/YdbQuery.java
@@ -15,21 +15,17 @@ public class YdbQuery {
     private final String originQuery;
     private final String preparedYQL;
     private final List<QueryStatement> statements;
-    private final YqlBatcher batch;
+    private final YqlBatcher batcher;
 
     private final QueryType type;
     private final boolean isPlainYQL;
 
-    YdbQuery(String originQuery, String preparedYQL, List<QueryStatement> stats, QueryType type) {
-        this(originQuery, preparedYQL, stats, null, type);
-    }
-
-    YdbQuery(String originQuery, String preparedYQL, List<QueryStatement> stats, YqlBatcher batch, QueryType type) {
+    YdbQuery(String originQuery, String preparedYQL, List<QueryStatement> stats, YqlBatcher batcher, QueryType type) {
         this.originQuery = originQuery;
         this.preparedYQL = preparedYQL;
         this.statements = stats;
         this.type = type;
-        this.batch = batch;
+        this.batcher = batcher;
 
         boolean hasJdbcParamters = false;
         for (QueryStatement st: statements) {
@@ -43,7 +39,7 @@ public class YdbQuery {
     }
 
     public YqlBatcher getYqlBatcher() {
-        return batch;
+        return batcher.isValidBatch() ? batcher : null;
     }
 
     public boolean isPlainYQL() {
@@ -66,32 +62,29 @@ public class YdbQuery {
         YdbQueryParser parser = new YdbQueryParser(opts.isDetectQueryType(), opts.isDetectJdbcParameters());
         String preparedYQL = parser.parseSQL(query);
 
-        QueryType type = opts.getForcedQueryType();
-        if (type == null) {
-            type = parser.detectQueryType();
-            YqlBatcher batcher = parser.getYqlBatcher();
+        QueryType type = null;
+        YqlBatcher batcher = parser.getYqlBatcher();
+        List<QueryStatement> statements = parser.getStatements();
 
-            if (opts.isForcedScanAndBulks()) {
-                if (batcher.isValidBatch()) {
-                    if (batcher.getCommand() == YqlBatcher.Cmd.UPSERT) {
-                        type = QueryType.BULK_QUERY;
-                    }
-                    if (batcher.getCommand() == YqlBatcher.Cmd.INSERT) {
-                        parser.getYqlBatcher().setForcedUpsert();
-                        type = QueryType.BULK_QUERY;
-                    }
-                }
-
-                if (parser.getStatements().size() == 1 && parser.getStatements().get(0).getCmd() == QueryCmd.SELECT) {
+        if (batcher.isValidBatch()) {
+            if (batcher.getCommand() == YqlBatcher.Cmd.INSERT && opts.isReplaceInsertToUpsert()) {
+                batcher.setForcedUpsert();
+            }
+            if (batcher.getCommand() == YqlBatcher.Cmd.UPSERT && opts.isForceBulkUpsert()) {
+                type = QueryType.BULK_QUERY;
+            }
+        } else {
+            if (opts.isForceScanSelect() && statements.size() == 1 && statements.get(0).getCmd() == QueryCmd.SELECT) {
+                if (parser.detectQueryType() == QueryType.DATA_QUERY) { // Only data queries may be converter to SCAN
                     type = QueryType.SCAN_QUERY;
                 }
             }
         }
 
-        if (parser.getYqlBatcher().isValidBatch()) {
-            return new YdbQuery(query, preparedYQL, parser.getStatements(), parser.getYqlBatcher(), type);
+        if (type == null) {
+            type = parser.detectQueryType();
         }
 
-        return new YdbQuery(query, preparedYQL, parser.getStatements(), type);
+        return new YdbQuery(query, preparedYQL, statements, batcher, type);
     }
 }

--- a/jdbc/src/main/java/tech/ydb/jdbc/settings/YdbConfig.java
+++ b/jdbc/src/main/java/tech/ydb/jdbc/settings/YdbConfig.java
@@ -184,8 +184,10 @@ public class YdbConfig {
             YdbQueryProperties.DISABLE_DETECT_SQL_OPERATIONS.toInfo(properties),
             YdbQueryProperties.DISABLE_JDBC_PARAMETERS.toInfo(properties),
             YdbQueryProperties.DISABLE_JDBC_PARAMETERS_DECLARE.toInfo(properties),
-            YdbQueryProperties.FORCE_QUERY_MODE.toInfo(properties),
-            YdbQueryProperties.FORCE_SCAN_BULKS.toInfo(properties),
+
+            YdbQueryProperties.REPLACE_INSERT_TO_UPSERT.toInfo(properties),
+            YdbQueryProperties.FORCE_BULK_UPSERT.toInfo(properties),
+            YdbQueryProperties.FORCE_SCAN_SELECT.toInfo(properties),
         };
     }
 

--- a/jdbc/src/main/java/tech/ydb/jdbc/settings/YdbValue.java
+++ b/jdbc/src/main/java/tech/ydb/jdbc/settings/YdbValue.java
@@ -17,6 +17,10 @@ class YdbValue<T> {
         return value;
     }
 
+    public T getValueOrOther(T other) {
+        return isPresent ? value : other;
+    }
+
     public boolean hasValue() {
         return isPresent;
     }

--- a/jdbc/src/test/java/tech/ydb/jdbc/YdbDriverOlapTablesTest.java
+++ b/jdbc/src/test/java/tech/ydb/jdbc/YdbDriverOlapTablesTest.java
@@ -216,7 +216,12 @@ public class YdbDriverOlapTablesTest {
 
     @Test
     public void forceScanAndBulkTest() throws SQLException {
-        try (Connection conn = DriverManager.getConnection(jdbcURL.withArg("forceScanAndBulk", "true").build())) {
+        try (Connection conn = DriverManager.getConnection(jdbcURL
+                .withArg("replaceInsertByUpsert", "true")
+                .withArg("forceBulkUpsert", "true")
+                .withArg("forceScanSelect", "true")
+                .build()
+        )) {
             try {
                 conn.createStatement().execute(DROP_TABLE);
             } catch (SQLException e) {

--- a/jdbc/src/test/java/tech/ydb/jdbc/YdbDriverTablesTest.java
+++ b/jdbc/src/test/java/tech/ydb/jdbc/YdbDriverTablesTest.java
@@ -28,9 +28,6 @@ public class YdbDriverTablesTest {
 
     private static final JdbcUrlHelper jdbcURL = new JdbcUrlHelper(ydb);
 
-    private final static String ERROR_SCAN_QUERY =
-            "Scan query should have a single result set. (S_ERROR)";
-
     private final static String ERROR_BULK_UNSUPPORTED =
             "BULK mode is available only for prepared statement with one UPSERT";
 
@@ -206,7 +203,12 @@ public class YdbDriverTablesTest {
 
     @Test
     public void forceScanAndBulkTest() throws SQLException {
-        try (Connection conn = DriverManager.getConnection(jdbcURL.withArg("forceScanAndBulk", "true").build())) {
+        try (Connection conn = DriverManager.getConnection(jdbcURL
+                .withArg("replaceInsertByUpsert", "true")
+                .withArg("forceBulkUpsert", "true")
+                .withArg("forceScanSelect", "true")
+                .build()
+        )) {
             try {
                 conn.createStatement().execute(DROP_TABLE);
             } catch (SQLException e) {

--- a/jdbc/src/test/java/tech/ydb/jdbc/settings/YdbDriverProperitesTest.java
+++ b/jdbc/src/test/java/tech/ydb/jdbc/settings/YdbDriverProperitesTest.java
@@ -334,8 +334,9 @@ public class YdbDriverProperitesTest {
             new DriverPropertyInfo("disableDetectSqlOperations", "false"),
             new DriverPropertyInfo("disableJdbcParameters", "false"),
             new DriverPropertyInfo("disableJdbcParameterDeclare", "false"),
-            new DriverPropertyInfo("forceQueryMode", ""),
-            new DriverPropertyInfo("forceScanAndBulk", "false"),
+            new DriverPropertyInfo("replaceInsertByUpsert", "false"),
+            new DriverPropertyInfo("forceBulkUpsert", "false"),
+            new DriverPropertyInfo("forceScanSelect", "false"),
         };
     }
 
@@ -373,8 +374,9 @@ public class YdbDriverProperitesTest {
             new DriverPropertyInfo("disableDetectSqlOperations", "true"),
             new DriverPropertyInfo("disableJdbcParameters", "true"),
             new DriverPropertyInfo("disableJdbcParameterDeclare", "true"),
-            new DriverPropertyInfo("forceQueryMode", "SCAN_QUERY"),
-            new DriverPropertyInfo("forceScanAndBulk", "true"),
+            new DriverPropertyInfo("replaceInsertByUpsert", "true"),
+            new DriverPropertyInfo("forceBulkUpsert", "true"),
+            new DriverPropertyInfo("forceScanSelect", "true"),
         };
     }
 


### PR DESCRIPTION
Replace options `forceQueryMode` and `forceScanAndBulk` by `replaceInsertByUpsert`, `forceBulkUpsert`, `forceScanSelect`