### PR TITLE
Fix unsigned integer round-trip in JDBC driver.

### DIFF
--- a/jdbc/src/main/java/tech/ydb/jdbc/common/MappingGetters.java
+++ b/jdbc/src/main/java/tech/ydb/jdbc/common/MappingGetters.java
@@ -5,6 +5,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.net.URL;
 import java.sql.SQLException;
 import java.time.Duration;
@@ -154,7 +155,7 @@ public class MappingGetters {
             case Int64:
                 return value -> String.valueOf(value.getInt64());
             case Uint64:
-                return value -> String.valueOf(value.getUint64());
+                return value -> Long.toUnsignedString(value.getUint64());
             case Float:
                 return value -> String.valueOf(value.getFloat());
             case Double:
@@ -291,6 +292,31 @@ public class MappingGetters {
         return (byte) value;
     }
 
+    private static BigInteger uint64ToBigInteger(long unsignedValue) {
+        return new BigInteger(Long.toUnsignedString(unsignedValue));
+    }
+
+    private static byte checkUnsignedByteValue(PrimitiveType id, long unsignedValue) throws SQLException {
+        if (unsignedValue < 0 || unsignedValue > Byte.MAX_VALUE) {
+            throw cannotConvert(id, byte.class, Long.toUnsignedString(unsignedValue));
+        }
+        return (byte) unsignedValue;
+    }
+
+    private static short checkUnsignedShortValue(PrimitiveType id, long unsignedValue) throws SQLException {
+        if (unsignedValue < 0 || unsignedValue > Short.MAX_VALUE) {
+            throw cannotConvert(id, short.class, Long.toUnsignedString(unsignedValue));
+        }
+        return (short) unsignedValue;
+    }
+
+    private static int checkUnsignedIntValue(PrimitiveType id, long unsignedValue) throws SQLException {
+        if (unsignedValue < 0 || unsignedValue > Integer.MAX_VALUE) {
+            throw cannotConvert(id, int.class, Long.toUnsignedString(unsignedValue));
+        }
+        return (int) unsignedValue;
+    }
+
     private static ValueToByte valueToByte(PrimitiveType id) {
         switch (id) {
             case Bool:
@@ -314,7 +340,7 @@ public class MappingGetters {
             case Uint32:
                 return value -> checkByteValue(id, value.getUint32());
             case Uint64:
-                return value -> checkByteValue(id, value.getUint64());
+                return value -> checkUnsignedByteValue(id, value.getUint64());
             default:
                 return castToByteNotSupported(id.name());
         }
@@ -359,7 +385,7 @@ public class MappingGetters {
             case Uint32:
                 return value -> checkShortValue(id, value.getUint32());
             case Uint64:
-                return value -> checkShortValue(id, value.getUint64());
+                return value -> checkUnsignedShortValue(id, value.getUint64());
             default:
                 return castToShortNotSupported(id.name());
         }
@@ -396,7 +422,7 @@ public class MappingGetters {
             case Uint32:
                 return value -> checkIntValue(id, value.getUint32());
             case Uint64:
-                return value -> checkIntValue(id, value.getUint64());
+                return value -> checkUnsignedIntValue(id, value.getUint64());
             case Date:
                 return value -> checkIntValue(id, value.getDate().toEpochDay());
             case Date32:
@@ -475,7 +501,7 @@ public class MappingGetters {
             case Uint32:
                 return PrimitiveReader::getUint32;
             case Uint64:
-                return PrimitiveReader::getUint64;
+                return value -> uint64ToBigInteger(value.getUint64()).floatValue();
             case Float:
                 return PrimitiveReader::getFloat;
             case Double:
@@ -504,7 +530,7 @@ public class MappingGetters {
             case Int64:
                 return PrimitiveReader::getInt64;
             case Uint64:
-                return PrimitiveReader::getUint64;
+                return value -> uint64ToBigInteger(value.getUint64()).doubleValue();
             case Float:
                 return PrimitiveReader::getFloat;
             case Double:
@@ -612,7 +638,7 @@ public class MappingGetters {
             case Int64:
                 return value -> BigDecimal.valueOf(value.getInt64());
             case Uint64:
-                return value -> BigDecimal.valueOf(value.getUint64());
+                return value -> new BigDecimal(uint64ToBigInteger(value.getUint64()));
             case Float:
                 return value -> BigDecimal.valueOf(value.getFloat());
             case Double:

--- a/jdbc/src/main/java/tech/ydb/jdbc/common/MappingSetters.java
+++ b/jdbc/src/main/java/tech/ydb/jdbc/common/MappingSetters.java
@@ -66,19 +66,19 @@ public class MappingSetters {
                 case Int8:
                     return x -> PrimitiveValue.newInt8(castAsByte(id, x));
                 case Uint8:
-                    return x -> PrimitiveValue.newUint8(castAsByte(id, x));
+                    return x -> PrimitiveValue.newUint8(castAsUint8(id, x));
                 case Int16:
                     return x -> PrimitiveValue.newInt16(castAsShort(id, x));
                 case Uint16:
-                    return x -> PrimitiveValue.newUint16(castAsShort(id, x));
+                    return x -> PrimitiveValue.newUint16(castAsUint16(id, x));
                 case Int32:
                     return x -> PrimitiveValue.newInt32(castAsInt(id, x));
                 case Uint32:
-                    return x -> PrimitiveValue.newUint32(castAsInt(id, x));
+                    return x -> PrimitiveValue.newUint32(castAsUint32(id, x));
                 case Int64:
                     return x -> PrimitiveValue.newInt64(castAsLong(id, x));
                 case Uint64:
-                    return x -> PrimitiveValue.newUint64(castAsLong(id, x));
+                    return x -> PrimitiveValue.newUint64(castAsUint64(id, x));
                 case Float:
                     return x -> PrimitiveValue.newFloat(castAsFloat(id, x));
                 case Double:
@@ -343,6 +343,118 @@ public class MappingSetters {
             }
         }
         throw castNotSupported(type, x);
+    }
+
+    private static byte castAsUint8(PrimitiveType type, Object x) throws SQLException {
+        BigInteger bi = toUnsignedBigInteger(type, x);
+        if (bi != null) {
+            if (bi.signum() < 0 || bi.bitLength() > 8) {
+                throw castNotSupported(type, x);
+            }
+            return bi.byteValue();
+        }
+        if (x instanceof String) {
+            try {
+                int parsed = Integer.parseUnsignedInt((String) x);
+                if ((parsed & ~0xFF) != 0) {
+                    throw castNotSupported(type, x);
+                }
+                return (byte) parsed;
+            } catch (NumberFormatException e) {
+                throw castNotSupported(type, x, e);
+            }
+        }
+        return castAsByte(type, x);
+    }
+
+    private static short castAsUint16(PrimitiveType type, Object x) throws SQLException {
+        BigInteger bi = toUnsignedBigInteger(type, x);
+        if (bi != null) {
+            if (bi.signum() < 0 || bi.bitLength() > 16) {
+                throw castNotSupported(type, x);
+            }
+            return bi.shortValue();
+        }
+        if (x instanceof String) {
+            try {
+                int parsed = Integer.parseUnsignedInt((String) x);
+                if ((parsed & ~0xFFFF) != 0) {
+                    throw castNotSupported(type, x);
+                }
+                return (short) parsed;
+            } catch (NumberFormatException e) {
+                throw castNotSupported(type, x, e);
+            }
+        }
+        return castAsShort(type, x);
+    }
+
+    private static int castAsUint32(PrimitiveType type, Object x) throws SQLException {
+        BigInteger bi = toUnsignedBigInteger(type, x);
+        if (bi != null) {
+            if (bi.signum() < 0 || bi.bitLength() > 32) {
+                throw castNotSupported(type, x);
+            }
+            return bi.intValue();
+        }
+        if (x instanceof String) {
+            try {
+                return Integer.parseUnsignedInt((String) x);
+            } catch (NumberFormatException e) {
+                throw castNotSupported(type, x, e);
+            }
+        }
+        return castAsInt(type, x);
+    }
+
+    private static long castAsUint64(PrimitiveType type, Object x) throws SQLException {
+        BigInteger bi = toUnsignedBigInteger(type, x);
+        if (bi != null) {
+            if (bi.signum() < 0 || bi.bitLength() > 64) {
+                throw castNotSupported(type, x);
+            }
+            return bi.longValue();
+        }
+        if (x instanceof String) {
+            try {
+                return Long.parseUnsignedLong((String) x);
+            } catch (NumberFormatException e) {
+                throw castNotSupported(type, x, e);
+            }
+        }
+        return castAsLong(type, x);
+    }
+
+    /**
+     * Converts BigInteger / BigDecimal / Float / Double inputs to a non-null BigInteger
+     * for unsigned-range validation by the caller. Returns null for other types so the
+     * caller can route them through the signed cast helpers (castAsByte/Short/Int/Long).
+     * Errors are reported against the original Object x so messages identify the
+     * user-visible input (e.g. 1.5f stays a Float in the error, not a BigDecimal).
+     */
+    private static BigInteger toUnsignedBigInteger(PrimitiveType type, Object x) throws SQLException {
+        if (x instanceof BigInteger) {
+            return (BigInteger) x;
+        }
+        if (x instanceof BigDecimal) {
+            try {
+                return ((BigDecimal) x).toBigIntegerExact();
+            } catch (ArithmeticException e) {
+                throw castNotSupported(type, x, e);
+            }
+        }
+        if (x instanceof Float || x instanceof Double) {
+            double d = ((Number) x).doubleValue();
+            if (Double.isNaN(d) || Double.isInfinite(d)) {
+                throw castNotSupported(type, x);
+            }
+            try {
+                return BigDecimal.valueOf(d).toBigIntegerExact();
+            } catch (ArithmeticException e) {
+                throw castNotSupported(type, x, e);
+            }
+        }
+        return null;
     }
 
     private static float castAsFloat(PrimitiveType type, Object x) throws SQLException {

--- a/jdbc/src/test/java/tech/ydb/jdbc/common/MappingGettersTest.java
+++ b/jdbc/src/test/java/tech/ydb/jdbc/common/MappingGettersTest.java
@@ -1,0 +1,127 @@
+package tech.ydb.jdbc.common;
+
+import java.lang.reflect.Proxy;
+import java.math.BigDecimal;
+import java.sql.SQLException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import tech.ydb.table.result.ValueReader;
+import tech.ydb.table.values.PrimitiveType;
+
+class MappingGettersTest {
+    private final YdbTypes types = new YdbTypes(false);
+    private final TypeDescription uint64 = types.find(PrimitiveType.Uint64);
+
+    private static ValueReader uint64Reader(long rawBits) {
+        return (ValueReader) Proxy.newProxyInstance(
+                ValueReader.class.getClassLoader(),
+                new Class[] {ValueReader.class},
+                (proxy, method, args) -> {
+                    if ("getUint64".equals(method.getName())) {
+                        return rawBits;
+                    }
+                    throw new UnsupportedOperationException("Stub does not implement " + method);
+                }
+        );
+    }
+
+    @Test
+    void uint64StringPreservesUnsignedRange() throws SQLException {
+        Assertions.assertEquals("0", uint64.getters().readString(uint64Reader(0L)));
+        Assertions.assertEquals(
+                String.valueOf(Long.MAX_VALUE),
+                uint64.getters().readString(uint64Reader(Long.MAX_VALUE))
+        );
+        // 2^63 — first value above signed long, raw bits = Long.MIN_VALUE.
+        Assertions.assertEquals(
+                "9223372036854775808",
+                uint64.getters().readString(uint64Reader(Long.MIN_VALUE))
+        );
+        // 2^64 - 1 — Uint64 max, raw bits = -1L.
+        Assertions.assertEquals(
+                "18446744073709551615",
+                uint64.getters().readString(uint64Reader(-1L))
+        );
+    }
+
+    @Test
+    void uint64BigDecimalPreservesUnsignedRange() throws SQLException {
+        Assertions.assertEquals(
+                BigDecimal.ZERO,
+                uint64.getters().readBigDecimal(uint64Reader(0L))
+        );
+        Assertions.assertEquals(
+                new BigDecimal("18446744073709551615"),
+                uint64.getters().readBigDecimal(uint64Reader(-1L))
+        );
+        Assertions.assertEquals(
+                new BigDecimal("9223372036854775808"),
+                uint64.getters().readBigDecimal(uint64Reader(Long.MIN_VALUE))
+        );
+    }
+
+    @Test
+    void uint64ByteRejectsValuesAbove127() {
+        Assertions.assertThrows(SQLException.class, () -> uint64.getters().readByte(uint64Reader(128L)));
+        // 2^64 - 1 must NOT silently come back as -1 (the pre-fix behavior).
+        Assertions.assertThrows(SQLException.class, () -> uint64.getters().readByte(uint64Reader(-1L)));
+    }
+
+    @Test
+    void uint64ByteAcceptsSmallValues() throws SQLException {
+        Assertions.assertEquals((byte) 0, uint64.getters().readByte(uint64Reader(0L)));
+        Assertions.assertEquals((byte) 127, uint64.getters().readByte(uint64Reader(127L)));
+    }
+
+    @Test
+    void uint64ShortRejectsOutOfRange() {
+        Assertions.assertThrows(SQLException.class, () -> uint64.getters().readShort(uint64Reader(32768L)));
+        Assertions.assertThrows(SQLException.class, () -> uint64.getters().readShort(uint64Reader(-1L)));
+    }
+
+    @Test
+    void uint64ShortAcceptsSmallValues() throws SQLException {
+        Assertions.assertEquals((short) 32767, uint64.getters().readShort(uint64Reader(32767L)));
+    }
+
+    @Test
+    void uint64IntRejectsOutOfRange() {
+        Assertions.assertThrows(SQLException.class,
+                () -> uint64.getters().readInt(uint64Reader((long) Integer.MAX_VALUE + 1)));
+        Assertions.assertThrows(SQLException.class, () -> uint64.getters().readInt(uint64Reader(-1L)));
+    }
+
+    @Test
+    void uint64IntAcceptsSmallValues() throws SQLException {
+        Assertions.assertEquals(Integer.MAX_VALUE, uint64.getters().readInt(uint64Reader(Integer.MAX_VALUE)));
+    }
+
+    @Test
+    void uint64LongReturnsRawBits() throws SQLException {
+        // Contract: getLong on Uint64 returns the 64-bit pattern as signed long.
+        // Values above Long.MAX_VALUE come back as their two's-complement representation.
+        Assertions.assertEquals(0L, uint64.getters().readLong(uint64Reader(0L)));
+        Assertions.assertEquals(Long.MAX_VALUE, uint64.getters().readLong(uint64Reader(Long.MAX_VALUE)));
+        Assertions.assertEquals(-1L, uint64.getters().readLong(uint64Reader(-1L)));
+    }
+
+    @Test
+    void uint64FloatPreservesUnsignedRange() throws SQLException {
+        // For values above Long.MAX_VALUE the raw long is negative; pre-fix (float) cast
+        // would produce a negative float. Now goes through unsigned BigInteger.
+        Assertions.assertEquals(0.0f, uint64.getters().readFloat(uint64Reader(0L)));
+        Assertions.assertEquals(1.8446744E19f, uint64.getters().readFloat(uint64Reader(-1L)), 1e13f);
+        Assertions.assertTrue(uint64.getters().readFloat(uint64Reader(-1L)) > 0,
+                "Uint64 max must come back as a positive float");
+    }
+
+    @Test
+    void uint64DoublePreservesUnsignedRange() throws SQLException {
+        Assertions.assertEquals(0.0d, uint64.getters().readDouble(uint64Reader(0L)));
+        Assertions.assertEquals(1.8446744073709552E19d, uint64.getters().readDouble(uint64Reader(-1L)), 1.0d);
+        Assertions.assertTrue(uint64.getters().readDouble(uint64Reader(-1L)) > 0,
+                "Uint64 max must come back as a positive double");
+    }
+}

--- a/jdbc/src/test/java/tech/ydb/jdbc/common/MappingSettersTest.java
+++ b/jdbc/src/test/java/tech/ydb/jdbc/common/MappingSettersTest.java
@@ -1,0 +1,160 @@
+package tech.ydb.jdbc.common;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.SQLException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import tech.ydb.table.values.PrimitiveType;
+import tech.ydb.table.values.PrimitiveValue;
+import tech.ydb.table.values.Value;
+
+class MappingSettersTest {
+    private final YdbTypes types = new YdbTypes(false);
+    private final TypeDescription uint8 = types.find(PrimitiveType.Uint8);
+    private final TypeDescription uint16 = types.find(PrimitiveType.Uint16);
+    private final TypeDescription uint32 = types.find(PrimitiveType.Uint32);
+    private final TypeDescription uint64 = types.find(PrimitiveType.Uint64);
+
+    @Test
+    void castUint8FromStringMax() throws SQLException {
+        Assertions.assertEquals(PrimitiveValue.newUint8((byte) 0xFF), uint8.toYdbValue("255"));
+    }
+
+    @Test
+    void castUint8FromBigIntegerMax() throws SQLException {
+        Assertions.assertEquals(PrimitiveValue.newUint8((byte) 0xFF), uint8.toYdbValue(BigInteger.valueOf(255)));
+    }
+
+    @Test
+    void rejectUint8Overflow() {
+        Assertions.assertThrows(SQLException.class, () -> uint8.toYdbValue("256"));
+        Assertions.assertThrows(SQLException.class, () -> uint8.toYdbValue(BigInteger.valueOf(256)));
+        Assertions.assertThrows(SQLException.class, () -> uint8.toYdbValue("-1"));
+        Assertions.assertThrows(SQLException.class, () -> uint8.toYdbValue(BigInteger.valueOf(-1)));
+    }
+
+    @Test
+    void castUint16FromStringMax() throws SQLException {
+        Assertions.assertEquals(PrimitiveValue.newUint16((short) 0xFFFF), uint16.toYdbValue("65535"));
+    }
+
+    @Test
+    void castUint16FromBigIntegerMax() throws SQLException {
+        Assertions.assertEquals(PrimitiveValue.newUint16((short) 0xFFFF), uint16.toYdbValue(BigInteger.valueOf(65535)));
+    }
+
+    @Test
+    void rejectUint16Overflow() {
+        Assertions.assertThrows(SQLException.class, () -> uint16.toYdbValue("65536"));
+        Assertions.assertThrows(SQLException.class, () -> uint16.toYdbValue(BigInteger.valueOf(65536)));
+        Assertions.assertThrows(SQLException.class, () -> uint16.toYdbValue("-1"));
+        Assertions.assertThrows(SQLException.class, () -> uint16.toYdbValue(BigInteger.valueOf(-1)));
+    }
+
+    @Test
+    void castUint32FromStringMax() throws SQLException {
+        Assertions.assertEquals(PrimitiveValue.newUint32(0xFFFFFFFF), uint32.toYdbValue("4294967295"));
+    }
+
+    @Test
+    void castUint32FromBigIntegerMax() throws SQLException {
+        Assertions.assertEquals(PrimitiveValue.newUint32(0xFFFFFFFF), uint32.toYdbValue(new BigInteger("4294967295")));
+    }
+
+    @Test
+    void rejectUint32Overflow() {
+        Assertions.assertThrows(SQLException.class, () -> uint32.toYdbValue("4294967296"));
+        Assertions.assertThrows(SQLException.class, () -> uint32.toYdbValue(new BigInteger("4294967296")));
+        Assertions.assertThrows(SQLException.class, () -> uint32.toYdbValue("-1"));
+        Assertions.assertThrows(SQLException.class, () -> uint32.toYdbValue(BigInteger.valueOf(-1)));
+    }
+
+    @Test
+    void castUint64FromBigIntegerAboveLongMax() throws SQLException {
+        BigInteger input = new BigInteger("9223372036854775808"); // Long.MAX_VALUE + 1
+        Value<?> value = uint64.toYdbValue(input);
+
+        Assertions.assertEquals(PrimitiveValue.newUint64(Long.parseUnsignedLong("9223372036854775808")), value);
+    }
+
+    @Test
+    void castUint64FromBigIntegerMax() throws SQLException {
+        BigInteger input = new BigInteger("18446744073709551615"); // 2^64 - 1
+        Value<?> value = uint64.toYdbValue(input);
+
+        Assertions.assertEquals(PrimitiveValue.newUint64(Long.parseUnsignedLong("18446744073709551615")), value);
+    }
+
+    @Test
+    void castUint64FromStringMax() throws SQLException {
+        Value<?> value = uint64.toYdbValue("18446744073709551615");
+
+        Assertions.assertEquals(PrimitiveValue.newUint64(Long.parseUnsignedLong("18446744073709551615")), value);
+    }
+
+    @Test
+    void rejectUint64BigIntegerOverflow() {
+        BigInteger overflow = new BigInteger("18446744073709551616"); // 2^64
+
+        Assertions.assertThrows(SQLException.class, () -> uint64.toYdbValue(overflow));
+    }
+
+    @Test
+    void rejectUint64BigIntegerNegative() {
+        Assertions.assertThrows(SQLException.class, () -> uint64.toYdbValue(new BigInteger("-1")));
+    }
+
+    @Test
+    void rejectUint64StringNegative() {
+        Assertions.assertThrows(SQLException.class, () -> uint64.toYdbValue("-1"));
+    }
+
+    @Test
+    void castUintFromBigDecimal() throws SQLException {
+        Assertions.assertEquals(PrimitiveValue.newUint8((byte) 0xFF), uint8.toYdbValue(new BigDecimal("255")));
+        Assertions.assertEquals(PrimitiveValue.newUint16((short) 0xFFFF), uint16.toYdbValue(new BigDecimal("65535.0")));
+        Assertions.assertEquals(PrimitiveValue.newUint32(0xFFFFFFFF), uint32.toYdbValue(new BigDecimal("4294967295.000")));
+        Assertions.assertEquals(
+                PrimitiveValue.newUint64(Long.parseUnsignedLong("18446744073709551615")),
+                uint64.toYdbValue(new BigDecimal("18446744073709551615"))
+        );
+    }
+
+    @Test
+    void rejectUintBigDecimalWithFraction() {
+        Assertions.assertThrows(SQLException.class, () -> uint8.toYdbValue(new BigDecimal("1.5")));
+        Assertions.assertThrows(SQLException.class, () -> uint16.toYdbValue(new BigDecimal("100.001")));
+        Assertions.assertThrows(SQLException.class, () -> uint32.toYdbValue(new BigDecimal("0.5")));
+        Assertions.assertThrows(SQLException.class, () -> uint64.toYdbValue(new BigDecimal("1.0000000001")));
+    }
+
+    @Test
+    void rejectUintBigDecimalOverflow() {
+        Assertions.assertThrows(SQLException.class, () -> uint8.toYdbValue(new BigDecimal("256")));
+        Assertions.assertThrows(SQLException.class, () -> uint8.toYdbValue(new BigDecimal("-1")));
+        Assertions.assertThrows(SQLException.class, () -> uint64.toYdbValue(new BigDecimal("18446744073709551616")));
+    }
+
+    @Test
+    void castUintFromFloatAndDouble() throws SQLException {
+        Assertions.assertEquals(PrimitiveValue.newUint8((byte) 200), uint8.toYdbValue(200.0f));
+        Assertions.assertEquals(PrimitiveValue.newUint8((byte) 200), uint8.toYdbValue(200.0d));
+        Assertions.assertEquals(PrimitiveValue.newUint32((int) 4_000_000_000L), uint32.toYdbValue(4_000_000_000.0d));
+    }
+
+    @Test
+    void rejectUintFloatDoubleWithFraction() {
+        Assertions.assertThrows(SQLException.class, () -> uint8.toYdbValue(1.5f));
+        Assertions.assertThrows(SQLException.class, () -> uint16.toYdbValue(100.5d));
+    }
+
+    @Test
+    void rejectUintFloatDoubleNonFinite() {
+        Assertions.assertThrows(SQLException.class, () -> uint8.toYdbValue(Double.NaN));
+        Assertions.assertThrows(SQLException.class, () -> uint8.toYdbValue(Double.POSITIVE_INFINITY));
+        Assertions.assertThrows(SQLException.class, () -> uint64.toYdbValue(Float.NEGATIVE_INFINITY));
+    }
+}

--- a/jdbc/src/test/java/tech/ydb/jdbc/impl/YdbPreparedStatementTest.java
+++ b/jdbc/src/test/java/tech/ydb/jdbc/impl/YdbPreparedStatementTest.java
@@ -1,6 +1,7 @@
 package tech.ydb.jdbc.impl;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.net.URL;
 import java.sql.Connection;
 import java.sql.Date;
@@ -2243,6 +2244,623 @@ public class YdbPreparedStatementTest {
 
                 Assertions.assertFalse(rs.next());
             }
+        }
+    }
+
+    @ParameterizedTest(name = "with {0}")
+    @EnumSource(SqlQueries.JdbcQuery.class)
+    public void uint8Test(SqlQueries.JdbcQuery query) throws SQLException {
+        String upsert = TEST_TABLE.upsertOne(query, "c_Uint8", "Uint8");
+        int ydbSqlType = YdbConst.SQL_KIND_PRIMITIVE + PrimitiveType.Uint8.ordinal();
+        boolean castingSupported = query != SqlQueries.JdbcQuery.IN_MEMORY;
+
+        try (PreparedStatement ps = jdbc.connection().prepareStatement(upsert)) {
+            ps.setInt(1, 1);
+            if (castingSupported) {
+                ps.setByte(2, (byte) 0);
+            } else {
+                ps.setObject(2, (byte) 0, ydbSqlType);
+            }
+            ps.execute();
+
+            ps.setInt(1, 2);
+            if (castingSupported) {
+                ps.setByte(2, Byte.MAX_VALUE); // 127
+            } else {
+                ps.setObject(2, Byte.MAX_VALUE, ydbSqlType);
+            }
+            ps.execute();
+
+            // BigInteger above signed byte max — pre-fix: castAsByte had no BigInteger branch.
+            ps.setInt(1, 3);
+            ps.setObject(2, BigInteger.valueOf(128), ydbSqlType);
+            ps.execute();
+
+            ps.setInt(1, 4);
+            ps.setObject(2, BigInteger.valueOf(200), ydbSqlType);
+            ps.execute();
+
+            // String above signed byte max — pre-fix: Byte.parseByte threw NumberFormatException.
+            ps.setInt(1, 5);
+            ps.setObject(2, "200", ydbSqlType);
+            ps.execute();
+
+            ps.setInt(1, 6);
+            ps.setObject(2, BigInteger.valueOf(255), ydbSqlType);
+            ps.execute();
+
+            ps.setInt(1, 7);
+            ps.setObject(2, "255", ydbSqlType);
+            ps.execute();
+
+            // Boolean & Utf8 -> Uint8 — server-side cast in castingSupported mode,
+            // driver-side cast (via castAsByte) in IN_MEMORY mode.
+            ps.setInt(1, 8);
+            if (castingSupported) {
+                ps.setBoolean(2, true);
+            } else {
+                ps.setObject(2, true, ydbSqlType);
+            }
+            ps.execute();
+
+            ps.setInt(1, 9);
+            if (castingSupported) {
+                ps.setString(2, "42");
+            } else {
+                ps.setObject(2, "42", ydbSqlType);
+            }
+            ps.execute();
+
+            // BigDecimal/Float/Double — supported via setObject(value, ydbSqlType).
+            ps.setInt(1, 10);
+            ps.setObject(2, new BigDecimal("100"), ydbSqlType);
+            ps.execute();
+
+            ps.setInt(1, 11);
+            ps.setObject(2, 12.0f, ydbSqlType);
+            ps.execute();
+
+            ps.setInt(1, 12);
+            ps.setObject(2, 13.0d, ydbSqlType);
+            ps.execute();
+
+            ExceptionAssert.sqlException("Cannot cast [class java.math.BigInteger: 256] to [Uint8]",
+                    () -> ps.setObject(2, BigInteger.valueOf(256), ydbSqlType)
+            );
+            ExceptionAssert.sqlException("Cannot cast [class java.math.BigInteger: -1] to [Uint8]",
+                    () -> ps.setObject(2, BigInteger.valueOf(-1), ydbSqlType)
+            );
+            ExceptionAssert.sqlException("Cannot cast [class java.lang.String: 256] to [Uint8]",
+                    () -> ps.setObject(2, "256", ydbSqlType)
+            );
+
+            // BigDecimal with fractional part / floating-point with fraction — rejected.
+            ExceptionAssert.sqlException("Cannot cast [class java.math.BigDecimal: 1.5] to [Uint8]",
+                    () -> ps.setObject(2, new BigDecimal("1.5"), ydbSqlType)
+            );
+            ExceptionAssert.sqlException("Cannot cast [class java.lang.Float: 1.5] to [Uint8]",
+                    () -> ps.setObject(2, 1.5f, ydbSqlType)
+            );
+            ExceptionAssert.sqlException("Cannot cast [class java.lang.Double: NaN] to [Uint8]",
+                    () -> ps.setObject(2, Double.NaN, ydbSqlType)
+            );
+            // Time/Date/Timestamp are not meaningful for Uint8 (their numeric forms
+            // never fit 0..255). Driver rejects with castNotSupported.
+            ExceptionAssert.sqlException("Cannot cast [class java.sql.Time: 10:30:00] to [Uint8]",
+                    () -> ps.setObject(2, Time.valueOf(LocalTime.of(10, 30, 0)), ydbSqlType)
+            );
+        }
+
+        try (Statement statement = jdbc.connection().createStatement()) {
+            try (ResultSet rs = statement.executeQuery(TEST_TABLE.selectColumn("c_Uint8"))) {
+                assertNextUint8(rs, 1, 0);
+                assertNextUint8(rs, 2, 127);
+                assertNextUint8(rs, 3, 128);
+                assertNextUint8(rs, 4, 200);
+                assertNextUint8(rs, 5, 200);
+                assertNextUint8(rs, 6, 255);
+                assertNextUint8(rs, 7, 255);
+                assertNextUint8(rs, 8, 1);
+                assertNextUint8(rs, 9, 42);
+                assertNextUint8(rs, 10, 100);
+                assertNextUint8(rs, 11, 12);
+                assertNextUint8(rs, 12, 13);
+
+                Assertions.assertFalse(rs.next());
+            }
+        }
+    }
+
+    private void assertNextUint8(ResultSet rs, int key, int value) throws SQLException {
+        Assertions.assertTrue(rs.next());
+        Assertions.assertEquals(key, rs.getInt("key"));
+
+        Object obj = rs.getObject("c_Uint8");
+        Assertions.assertTrue(obj instanceof Integer);
+        Assertions.assertEquals(value, obj);
+
+        if (value <= Byte.MAX_VALUE) {
+            Assertions.assertEquals((byte) value, rs.getByte("c_Uint8"));
+        } else {
+            String msg = String.format("Cannot cast [Uint8] with value [%s] to [byte]", value);
+            ExceptionAssert.sqlException(msg, () -> rs.getByte("c_Uint8"));
+        }
+
+        Assertions.assertEquals((short) value, rs.getShort("c_Uint8"));
+        Assertions.assertEquals(value, rs.getInt("c_Uint8"));
+        Assertions.assertEquals((long) value, rs.getLong("c_Uint8"));
+        Assertions.assertEquals(String.valueOf(value), rs.getString("c_Uint8"));
+        Assertions.assertEquals(BigDecimal.valueOf(value), rs.getBigDecimal("c_Uint8"));
+        Assertions.assertEquals(value != 0, rs.getBoolean("c_Uint8"));
+    }
+
+    @ParameterizedTest(name = "with {0}")
+    @EnumSource(SqlQueries.JdbcQuery.class)
+    public void uint16Test(SqlQueries.JdbcQuery query) throws SQLException {
+        String upsert = TEST_TABLE.upsertOne(query, "c_Uint16", "Uint16");
+        int ydbSqlType = YdbConst.SQL_KIND_PRIMITIVE + PrimitiveType.Uint16.ordinal();
+        boolean castingSupported = query != SqlQueries.JdbcQuery.IN_MEMORY;
+
+        try (PreparedStatement ps = jdbc.connection().prepareStatement(upsert)) {
+            ps.setInt(1, 1);
+            if (castingSupported) {
+                ps.setShort(2, (short) 0);
+            } else {
+                ps.setObject(2, (short) 0, ydbSqlType);
+            }
+            ps.execute();
+
+            ps.setInt(1, 2);
+            if (castingSupported) {
+                ps.setShort(2, Short.MAX_VALUE); // 32767
+            } else {
+                ps.setObject(2, Short.MAX_VALUE, ydbSqlType);
+            }
+            ps.execute();
+
+            ps.setInt(1, 3);
+            ps.setObject(2, BigInteger.valueOf(Short.MAX_VALUE + 1), ydbSqlType); // 32768
+            ps.execute();
+
+            ps.setInt(1, 4);
+            ps.setObject(2, BigInteger.valueOf(50000), ydbSqlType);
+            ps.execute();
+
+            ps.setInt(1, 5);
+            ps.setObject(2, "50000", ydbSqlType);
+            ps.execute();
+
+            ps.setInt(1, 6);
+            ps.setObject(2, BigInteger.valueOf(0xFFFF), ydbSqlType); // 65535
+            ps.execute();
+
+            ps.setInt(1, 7);
+            ps.setObject(2, "65535", ydbSqlType);
+            ps.execute();
+
+            ps.setInt(1, 8);
+            if (castingSupported) {
+                ps.setBoolean(2, true);
+            } else {
+                ps.setObject(2, true, ydbSqlType);
+            }
+            ps.execute();
+
+            ps.setInt(1, 9);
+            if (castingSupported) {
+                ps.setString(2, "42");
+            } else {
+                ps.setObject(2, "42", ydbSqlType);
+            }
+            ps.execute();
+
+            ps.setInt(1, 10);
+            ps.setObject(2, new BigDecimal("40000"), ydbSqlType);
+            ps.execute();
+
+            ps.setInt(1, 11);
+            ps.setObject(2, 1234.0f, ydbSqlType);
+            ps.execute();
+
+            ps.setInt(1, 12);
+            ps.setObject(2, 5678.0d, ydbSqlType);
+            ps.execute();
+
+            ExceptionAssert.sqlException("Cannot cast [class java.math.BigInteger: 65536] to [Uint16]",
+                    () -> ps.setObject(2, BigInteger.valueOf(65536), ydbSqlType)
+            );
+            ExceptionAssert.sqlException("Cannot cast [class java.math.BigInteger: -1] to [Uint16]",
+                    () -> ps.setObject(2, BigInteger.valueOf(-1), ydbSqlType)
+            );
+            ExceptionAssert.sqlException("Cannot cast [class java.lang.String: 65536] to [Uint16]",
+                    () -> ps.setObject(2, "65536", ydbSqlType)
+            );
+            ExceptionAssert.sqlException("Cannot cast [class java.math.BigDecimal: 100.5] to [Uint16]",
+                    () -> ps.setObject(2, new BigDecimal("100.5"), ydbSqlType)
+            );
+            ExceptionAssert.sqlException("Cannot cast [class java.lang.Double: Infinity] to [Uint16]",
+                    () -> ps.setObject(2, Double.POSITIVE_INFINITY, ydbSqlType)
+            );
+            ExceptionAssert.sqlException("Cannot cast [class java.sql.Time: 10:30:00] to [Uint16]",
+                    () -> ps.setObject(2, Time.valueOf(LocalTime.of(10, 30, 0)), ydbSqlType)
+            );
+        }
+
+        try (Statement statement = jdbc.connection().createStatement()) {
+            try (ResultSet rs = statement.executeQuery(TEST_TABLE.selectColumn("c_Uint16"))) {
+                assertNextUint16(rs, 1, 0);
+                assertNextUint16(rs, 2, Short.MAX_VALUE);
+                assertNextUint16(rs, 3, Short.MAX_VALUE + 1);
+                assertNextUint16(rs, 4, 50000);
+                assertNextUint16(rs, 5, 50000);
+                assertNextUint16(rs, 6, 0xFFFF);
+                assertNextUint16(rs, 7, 0xFFFF);
+                assertNextUint16(rs, 8, 1);
+                assertNextUint16(rs, 9, 42);
+                assertNextUint16(rs, 10, 40000);
+                assertNextUint16(rs, 11, 1234);
+                assertNextUint16(rs, 12, 5678);
+
+                Assertions.assertFalse(rs.next());
+            }
+        }
+    }
+
+    private void assertNextUint16(ResultSet rs, int key, int value) throws SQLException {
+        Assertions.assertTrue(rs.next());
+        Assertions.assertEquals(key, rs.getInt("key"));
+
+        Object obj = rs.getObject("c_Uint16");
+        Assertions.assertTrue(obj instanceof Integer);
+        Assertions.assertEquals(value, obj);
+
+        if (value <= Short.MAX_VALUE) {
+            Assertions.assertEquals((short) value, rs.getShort("c_Uint16"));
+        } else {
+            String msg = String.format("Cannot cast [Uint16] with value [%s] to [short]", value);
+            ExceptionAssert.sqlException(msg, () -> rs.getShort("c_Uint16"));
+        }
+
+        Assertions.assertEquals(value, rs.getInt("c_Uint16"));
+        Assertions.assertEquals((long) value, rs.getLong("c_Uint16"));
+        Assertions.assertEquals(String.valueOf(value), rs.getString("c_Uint16"));
+        Assertions.assertEquals(BigDecimal.valueOf(value), rs.getBigDecimal("c_Uint16"));
+        Assertions.assertEquals(value != 0, rs.getBoolean("c_Uint16"));
+    }
+
+    @ParameterizedTest(name = "with {0}")
+    @EnumSource(SqlQueries.JdbcQuery.class)
+    public void uint32Test(SqlQueries.JdbcQuery query) throws SQLException {
+        String upsert = TEST_TABLE.upsertOne(query, "c_Uint32", "Uint32");
+        int ydbSqlType = YdbConst.SQL_KIND_PRIMITIVE + PrimitiveType.Uint32.ordinal();
+        boolean castingSupported = query != SqlQueries.JdbcQuery.IN_MEMORY;
+
+        long uint32Max = 0xFFFFFFFFL; // 4294967295
+
+        try (PreparedStatement ps = jdbc.connection().prepareStatement(upsert)) {
+            ps.setInt(1, 1);
+            if (castingSupported) {
+                ps.setInt(2, 0);
+            } else {
+                ps.setObject(2, 0, ydbSqlType);
+            }
+            ps.execute();
+
+            ps.setInt(1, 2);
+            if (castingSupported) {
+                ps.setInt(2, Integer.MAX_VALUE); // 2147483647
+            } else {
+                ps.setObject(2, Integer.MAX_VALUE, ydbSqlType);
+            }
+            ps.execute();
+
+            ps.setInt(1, 3);
+            ps.setObject(2, BigInteger.valueOf((long) Integer.MAX_VALUE + 1), ydbSqlType); // 2147483648
+            ps.execute();
+
+            ps.setInt(1, 4);
+            ps.setObject(2, BigInteger.valueOf(4000000000L), ydbSqlType);
+            ps.execute();
+
+            ps.setInt(1, 5);
+            ps.setObject(2, "4000000000", ydbSqlType);
+            ps.execute();
+
+            ps.setInt(1, 6);
+            ps.setObject(2, BigInteger.valueOf(uint32Max), ydbSqlType);
+            ps.execute();
+
+            ps.setInt(1, 7);
+            ps.setObject(2, String.valueOf(uint32Max), ydbSqlType);
+            ps.execute();
+
+            ps.setInt(1, 8);
+            if (castingSupported) {
+                ps.setBoolean(2, true);
+            } else {
+                ps.setObject(2, true, ydbSqlType);
+            }
+            ps.execute();
+
+            ps.setInt(1, 9);
+            if (castingSupported) {
+                ps.setString(2, "42");
+            } else {
+                ps.setObject(2, "42", ydbSqlType);
+            }
+            ps.execute();
+
+            ps.setInt(1, 10);
+            ps.setObject(2, new BigDecimal("3000000000"), ydbSqlType); // > Integer.MAX_VALUE
+            ps.execute();
+
+            ps.setInt(1, 11);
+            ps.setObject(2, 1234.0f, ydbSqlType);
+            ps.execute();
+
+            ps.setInt(1, 12);
+            ps.setObject(2, 5_000_000.0d, ydbSqlType);
+            ps.execute();
+
+            // Time/Date — driver routes through castAsInt's existing branches.
+            ps.setInt(1, 13);
+            if (castingSupported) {
+                ps.setTime(2, Time.valueOf(LocalTime.of(10, 30, 0))); // 37800 sec-of-day
+            } else {
+                ps.setObject(2, Time.valueOf(LocalTime.of(10, 30, 0)), ydbSqlType);
+            }
+            ps.execute();
+
+            ps.setInt(1, 14);
+            if (castingSupported) {
+                ps.setDate(2, Date.valueOf(LocalDate.of(2025, Month.JANUARY, 1))); // 20089 epoch days
+            } else {
+                ps.setObject(2, Date.valueOf(LocalDate.of(2025, Month.JANUARY, 1)), ydbSqlType);
+            }
+            ps.execute();
+
+            ExceptionAssert.sqlException("Cannot cast [class java.math.BigInteger: 4294967296] to [Uint32]",
+                    () -> ps.setObject(2, BigInteger.valueOf(uint32Max + 1), ydbSqlType)
+            );
+            ExceptionAssert.sqlException("Cannot cast [class java.math.BigInteger: -1] to [Uint32]",
+                    () -> ps.setObject(2, BigInteger.valueOf(-1), ydbSqlType)
+            );
+            ExceptionAssert.sqlException("Cannot cast [class java.lang.String: 4294967296] to [Uint32]",
+                    () -> ps.setObject(2, "4294967296", ydbSqlType)
+            );
+            ExceptionAssert.sqlException("Cannot cast [class java.math.BigDecimal: 0.5] to [Uint32]",
+                    () -> ps.setObject(2, new BigDecimal("0.5"), ydbSqlType)
+            );
+            ExceptionAssert.sqlException("Cannot cast [class java.lang.Double: NaN] to [Uint32]",
+                    () -> ps.setObject(2, Double.NaN, ydbSqlType)
+            );
+        }
+
+        try (Statement statement = jdbc.connection().createStatement()) {
+            try (ResultSet rs = statement.executeQuery(TEST_TABLE.selectColumn("c_Uint32"))) {
+                assertNextUint32(rs, 1, 0L);
+                assertNextUint32(rs, 2, (long) Integer.MAX_VALUE);
+                assertNextUint32(rs, 3, (long) Integer.MAX_VALUE + 1);
+                assertNextUint32(rs, 4, 4000000000L);
+                assertNextUint32(rs, 5, 4000000000L);
+                assertNextUint32(rs, 6, uint32Max);
+                assertNextUint32(rs, 7, uint32Max);
+                assertNextUint32(rs, 8, 1L);
+                assertNextUint32(rs, 9, 42L);
+                assertNextUint32(rs, 10, 3000000000L);
+                assertNextUint32(rs, 11, 1234L);
+                assertNextUint32(rs, 12, 5_000_000L);
+                assertNextUint32(rs, 13, 10 * 3600L + 30 * 60); // 37800
+                assertNextUint32(rs, 14, LocalDate.of(2025, Month.JANUARY, 1).toEpochDay());
+
+                Assertions.assertFalse(rs.next());
+            }
+        }
+    }
+
+    private void assertNextUint32(ResultSet rs, int key, long value) throws SQLException {
+        Assertions.assertTrue(rs.next());
+        Assertions.assertEquals(key, rs.getInt("key"));
+
+        Object obj = rs.getObject("c_Uint32");
+        Assertions.assertTrue(obj instanceof Long);
+        Assertions.assertEquals(value, obj);
+
+        if (value <= Integer.MAX_VALUE) {
+            Assertions.assertEquals((int) value, rs.getInt("c_Uint32"));
+        } else {
+            String msg = String.format("Cannot cast [Uint32] with value [%s] to [int]", value);
+            ExceptionAssert.sqlException(msg, () -> rs.getInt("c_Uint32"));
+        }
+
+        Assertions.assertEquals(value, rs.getLong("c_Uint32"));
+        Assertions.assertEquals(String.valueOf(value), rs.getString("c_Uint32"));
+        Assertions.assertEquals(BigDecimal.valueOf(value), rs.getBigDecimal("c_Uint32"));
+        Assertions.assertEquals(value != 0, rs.getBoolean("c_Uint32"));
+    }
+
+    @ParameterizedTest(name = "with {0}")
+    @EnumSource(SqlQueries.JdbcQuery.class)
+    public void uint64Test(SqlQueries.JdbcQuery query) throws SQLException {
+        String upsert = TEST_TABLE.upsertOne(query, "c_Uint64", "Uint64");
+        int ydbSqlType = YdbConst.SQL_KIND_PRIMITIVE + PrimitiveType.Uint64.ordinal();
+        boolean castingSupported = query != SqlQueries.JdbcQuery.IN_MEMORY;
+
+        BigInteger uint64Max = BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE); // 18446744073709551615
+        BigInteger aboveSignedLong = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE); // 9223372036854775808
+
+        try (PreparedStatement ps = jdbc.connection().prepareStatement(upsert)) {
+            ps.setInt(1, 1);
+            if (castingSupported) {
+                ps.setLong(2, 0L);
+            } else {
+                ps.setObject(2, 0L, ydbSqlType);
+            }
+            ps.execute();
+
+            ps.setInt(1, 2);
+            if (castingSupported) {
+                ps.setLong(2, Long.MAX_VALUE);
+            } else {
+                ps.setObject(2, Long.MAX_VALUE, ydbSqlType);
+            }
+            ps.execute();
+
+            ps.setInt(1, 3);
+            ps.setObject(2, aboveSignedLong, ydbSqlType);
+            ps.execute();
+
+            ps.setInt(1, 4);
+            ps.setObject(2, aboveSignedLong.toString(), ydbSqlType);
+            ps.execute();
+
+            ps.setInt(1, 5);
+            ps.setObject(2, uint64Max, ydbSqlType);
+            ps.execute();
+
+            ps.setInt(1, 6);
+            ps.setObject(2, uint64Max.toString(), ydbSqlType);
+            ps.execute();
+
+            ps.setInt(1, 7);
+            if (castingSupported) {
+                ps.setBoolean(2, true);
+            } else {
+                ps.setObject(2, true, ydbSqlType);
+            }
+            ps.execute();
+
+            ps.setInt(1, 8);
+            if (castingSupported) {
+                ps.setString(2, "42");
+            } else {
+                ps.setObject(2, "42", ydbSqlType);
+            }
+            ps.execute();
+
+            ps.setInt(1, 9);
+            ps.setObject(2, new BigDecimal(uint64Max), ydbSqlType); // 2^64-1 via BigDecimal
+            ps.execute();
+
+            ps.setInt(1, 10);
+            ps.setObject(2, 12.0f, ydbSqlType);
+            ps.execute();
+
+            ps.setInt(1, 11);
+            ps.setObject(2, 13.0d, ydbSqlType);
+            ps.execute();
+
+            ps.setInt(1, 12);
+            if (castingSupported) {
+                ps.setTime(2, Time.valueOf(LocalTime.of(10, 30, 0))); // 37800 sec-of-day
+            } else {
+                ps.setObject(2, Time.valueOf(LocalTime.of(10, 30, 0)), ydbSqlType);
+            }
+            ps.execute();
+
+            ps.setInt(1, 13);
+            if (castingSupported) {
+                ps.setDate(2, Date.valueOf(LocalDate.of(2025, Month.JANUARY, 1)));
+            } else {
+                ps.setObject(2, Date.valueOf(LocalDate.of(2025, Month.JANUARY, 1)), ydbSqlType);
+            }
+            ps.execute();
+
+            ps.setInt(1, 14);
+            if (castingSupported) {
+                ps.setTimestamp(2, new Timestamp(TEST_TS.toEpochMilli()));
+            } else {
+                ps.setObject(2, new Timestamp(TEST_TS.toEpochMilli()), ydbSqlType);
+            }
+            ps.execute();
+
+            BigInteger overflow = uint64Max.add(BigInteger.ONE);
+            ExceptionAssert.sqlException(
+                    "Cannot cast [class java.math.BigInteger: " + overflow + "] to [Uint64]",
+                    () -> ps.setObject(2, overflow, ydbSqlType)
+            );
+            ExceptionAssert.sqlException("Cannot cast [class java.math.BigInteger: -1] to [Uint64]",
+                    () -> ps.setObject(2, BigInteger.valueOf(-1), ydbSqlType)
+            );
+            ExceptionAssert.sqlException(
+                    "Cannot cast [class java.lang.String: " + overflow + "] to [Uint64]",
+                    () -> ps.setObject(2, overflow.toString(), ydbSqlType)
+            );
+            ExceptionAssert.sqlException("Cannot cast [class java.math.BigDecimal: 1.5] to [Uint64]",
+                    () -> ps.setObject(2, new BigDecimal("1.5"), ydbSqlType)
+            );
+            ExceptionAssert.sqlException("Cannot cast [class java.lang.Float: NaN] to [Uint64]",
+                    () -> ps.setObject(2, Float.NaN, ydbSqlType)
+            );
+        }
+
+        try (Statement statement = jdbc.connection().createStatement()) {
+            try (ResultSet rs = statement.executeQuery(TEST_TABLE.selectColumn("c_Uint64"))) {
+                assertNextUint64(rs, 1, BigInteger.ZERO);
+                assertNextUint64(rs, 2, BigInteger.valueOf(Long.MAX_VALUE));
+                assertNextUint64(rs, 3, aboveSignedLong);
+                assertNextUint64(rs, 4, aboveSignedLong);
+                assertNextUint64(rs, 5, uint64Max);
+                assertNextUint64(rs, 6, uint64Max);
+                assertNextUint64(rs, 7, BigInteger.ONE);
+                assertNextUint64(rs, 8, BigInteger.valueOf(42));
+                assertNextUint64(rs, 9, uint64Max);
+                assertNextUint64(rs, 10, BigInteger.valueOf(12));
+                assertNextUint64(rs, 11, BigInteger.valueOf(13));
+                assertNextUint64(rs, 12, BigInteger.valueOf(10 * 3600L + 30 * 60)); // 37800
+                assertNextUint64(rs, 13, BigInteger.valueOf(LocalDate.of(2025, Month.JANUARY, 1).toEpochDay()));
+                assertNextUint64(rs, 14, BigInteger.valueOf(TEST_TS.toEpochMilli()));
+
+                Assertions.assertFalse(rs.next());
+            }
+        }
+    }
+
+    private void assertNextUint64(ResultSet rs, int key, BigInteger value) throws SQLException {
+        Assertions.assertTrue(rs.next());
+        Assertions.assertEquals(key, rs.getInt("key"));
+
+        // getLong/getObject preserve the raw 64-bit pattern (Uint64 -> Long is a
+        // signed reinterpretation, e.g. 2^64-1 -> -1L). getString/getBigDecimal,
+        // however, must reflect the true unsigned numeric value.
+        long rawBits = value.longValue();
+
+        Object obj = rs.getObject("c_Uint64");
+        Assertions.assertTrue(obj instanceof Long);
+        Assertions.assertEquals(rawBits, obj);
+
+        Assertions.assertEquals(rawBits, rs.getLong("c_Uint64"));
+        Assertions.assertEquals(rawBits != 0L, rs.getBoolean("c_Uint64"));
+
+        Assertions.assertEquals(value.toString(), rs.getString("c_Uint64"));
+        Assertions.assertEquals(new BigDecimal(value), rs.getBigDecimal("c_Uint64"));
+
+        // Narrow integer accessors: only succeed when the unsigned value fits
+        // the (signed) target's positive range; reject for values above it,
+        // including those that look "small" as raw bits (e.g. -1L for 2^64-1).
+        if (value.bitLength() <= 7) {
+            Assertions.assertEquals(value.byteValueExact(), rs.getByte("c_Uint64"));
+        } else {
+            ExceptionAssert.sqlException(
+                    String.format("Cannot cast [Uint64] with value [%s] to [byte]", value),
+                    () -> rs.getByte("c_Uint64")
+            );
+        }
+        if (value.bitLength() <= 15) {
+            Assertions.assertEquals(value.shortValueExact(), rs.getShort("c_Uint64"));
+        } else {
+            ExceptionAssert.sqlException(
+                    String.format("Cannot cast [Uint64] with value [%s] to [short]", value),
+                    () -> rs.getShort("c_Uint64")
+            );
+        }
+        if (value.bitLength() <= 31) {
+            Assertions.assertEquals(value.intValueExact(), rs.getInt("c_Uint64"));
+        } else {
+            ExceptionAssert.sqlException(
+                    String.format("Cannot cast [Uint64] with value [%s] to [int]", value),
+                    () -> rs.getInt("c_Uint64")
+            );
         }
     }
 


### PR DESCRIPTION
API surface, Uint8/16/32/64 columns:

  setByte/Short/Int/Long  — work natively (driver knows column type and
                             routes through unsigned setters in 4 of 5
                             JdbcQuery modes; only IN_MEMORY needs
                             setObject(value, ydbSqlType))
                             
  setBoolean              — true -> 1, false -> 0
  
  setString               — accepts unsigned decimal up to type max
  
  setBigDecimal           — accepts integral values; fractional parts and
                             out-of-range values are rejected
                             
  setFloat / setDouble    — accepts integral values; fractional, NaN,
                             Infinity rejected
                             
  setObject(BigInteger)   — accepts up to type max
  
  setObject(value, ydbSqlType=Uint*) — works for any of the above in any
                             JdbcQuery mode
                             
  setTime / setDate /
  
  setTimestamp            — supported only for Uint32/Uint64 (route
                             through castAsInt/castAsLong's existing
                             temporal branches); for Uint8/Uint16 the
                             numeric forms never fit, so driver rejects

Setter fixes (MappingSetters):

  * castAsUint8/16/32 had no BigInteger branch — setObject(BigInteger, ..) threw "Cannot cast" even for in-range values. Add unsigned-aware paths that range-check via signum() and bitLength().
  * castAsUint8/16/32/64 routed strings through Byte/Short/Integer/Long.parseXxx, which threw NumberFormatException on values above the signed maximum (e.g. "18446744073709551615" for Uint64). Switch to parseUnsignedInt/parseUnsignedLong with explicit bounds checks.
  * castAsUint64 truncated BigInteger via longValue() with no range check — values above 2^64-1 silently lost their high bits. Now rejected.
  * Add BigDecimal / Float / Double support via a shared toUnsignedBigInteger helper that uses toBigIntegerExact (rejecting fractional parts and NaN/Infinity), then routes through unsigned-range validation. The original Object identity is preserved in error messages so users see e.g. "Float: 1.5", not "BigDecimal: 1.5".

Getter fixes (MappingGetters), Uint64-only — Uint8/16/32 already round-trip correctly through their wider signed primitive types:

  * getString returned String.valueOf(long), giving "-1" for 2^64-1. Switch to Long.toUnsignedString.
  * getBigDecimal returned BigDecimal.valueOf(long), same problem. Build via BigInteger from the unsigned string.
  * getFloat / getDouble used implicit (float)/(double) cast on a signed long, producing -1.0 for 2^64-1. Route through new BigInteger(Long.toUnsignedString(...)).floatValue/doubleValue().
  * getByte/Short/Int used checkByteValue/checkShortValue/checkIntValue, whose signed two's-complement range check accepts -1L (the bit pattern of 2^64-1) and silently returns -1 for "Uint64 max -> byte". Add checkUnsignedByteValue/Short/Int that reject any negative raw long (unsigned > 2^63) and any value above the signed target's positive range, with an unsigned-string error message.

  * Behavior change: getByte/Short/Int on a Uint64 column with a value above the target's signed positive max now throw cleanly. Previously they silently truncated, returning e.g. -1 from a 2^64-1 column.
  * getLong and getObject keep returning the raw 64-bit pattern (signed long) — this is the JDBC contract; promoting getObject to BigInteger would be a breaking change and is left for separate discussion.
  * getInstant on Uint64 still uses Instant.ofEpochMilli on the raw long (unaffected by this change). Treating Uint64 as epoch-millis is an obscure path and was not in scope.

Tests:

  * MappingSettersTest covers BigInteger / String / BigDecimal / Float / Double inputs at boundaries (zero, signed max, type max, overflow, negative, fractional, NaN, Infinity) for all four Uint widths.
  * MappingGettersTest exercises Uint64 reads via getString / getBigDecimal / getByte / getShort / getInt / getLong / getFloat / getDouble on a Proxy-based ValueReader stub at the same boundaries.
  * YdbPreparedStatementTest's uint8/16/32/64Test follow the existing int/float/double pattern: parameterized over JdbcQuery, branching on castingSupported (false only for IN_MEMORY) — native setters in the supported branch, setObject(value, ydbSqlType) in IN_MEMORY. Each test exercises Number / BigInteger / String / Boolean / BigDecimal / Float / Double inputs as positives, asserts driver-side rejection of fractional / NaN / out-of-range values, and (uint32/uint64) asserts setTime / setDate / setTimestamp round-trip; Uint8/Uint16 explicitly assert setTime is rejected. assertNextUint64 verifies unsigned-correct getString / getBigDecimal and bounds-aware getByte / getShort / getInt.