### PR TITLE
Make YdbDriverProperitesTest pass on Windows.

### DIFF
--- a/jdbc/src/test/java/tech/ydb/jdbc/impl/helper/ExceptionAssert.java
+++ b/jdbc/src/test/java/tech/ydb/jdbc/impl/helper/ExceptionAssert.java
@@ -55,4 +55,12 @@ public class ExceptionAssert {
         );
         Assertions.assertEquals(message, ex.getMessage());
     }
+
+    public static void sqlExceptionStartsWith(String prefix, Executable exec) {
+        SQLException ex = Assertions.assertThrows(SQLException.class, exec,
+                "Invalid statement must throw SQLException"
+        );
+        Assertions.assertTrue(ex.getMessage() != null && ex.getMessage().startsWith(prefix),
+                "SQLException message '" + ex.getMessage() + "' should start with '" + prefix + "'");
+    }
 }

--- a/jdbc/src/test/java/tech/ydb/jdbc/settings/YdbDriverProperitesTest.java
+++ b/jdbc/src/test/java/tech/ydb/jdbc/settings/YdbDriverProperitesTest.java
@@ -193,7 +193,8 @@ public class YdbDriverProperitesTest {
     @MethodSource("tokensToCheck")
     public void getTokenAs(String token, String expectValue) throws SQLException {
         if ("file:".equals(token)) {
-            token += TOKEN_FILE.getAbsolutePath();
+            // Normalize to forward slashes so the URL stays valid on Windows (backslashes are illegal in queries).
+            token += TOKEN_FILE.getAbsolutePath().replace('\\', '/');
         }
 
         String url = "jdbc:ydb:ydb-demo.testhost.org:2135/test/db?token=" + token;
@@ -221,7 +222,7 @@ public class YdbDriverProperitesTest {
     @MethodSource("certificatesToCheck")
     public void getCaCertificateAs(String certificate, String expectValue) throws SQLException {
         if ("file:".equals(certificate)) {
-            certificate += CERTIFICATE_FILE.getAbsolutePath();
+            certificate += CERTIFICATE_FILE.getAbsolutePath().replace('\\', '/');
         }
         String url = "jdbc:ydb:ydb-demo.testhost.org:2135/test/db" +
                 "?secureConnectionCertificate=" + certificate;
@@ -234,14 +235,16 @@ public class YdbDriverProperitesTest {
 
     @ParameterizedTest(name = "[{index}] {0} => {1}")
     @CsvSource(delimiter = ',', value = {
+        // Suffix only — the underlying IOException message is OS-specific, so we match a stable prefix.
         "classpath:data/unknown-file.txt,resource not found",
-        "file:data/unknown-file.txt,data/unknown-file.txt (No such file or directory)",
+        "file:data/unknown-file.txt,",
     })
     public void getCaCertificateAsInvalid(String value, String message) {
         String url = "jdbc:ydb:ydb-demo.testhost.org:2135/test/db" +
                 "?secureConnectionCertificate=" + value;
-        ExceptionAssert.sqlException(
-                "Cannot process value " + value + " for option secureConnectionCertificate: " + message,
+        String expectedPrefix = "Cannot process value " + value + " for option secureConnectionCertificate: "
+                + (message == null ? "" : message);
+        ExceptionAssert.sqlExceptionStartsWith(expectedPrefix,
                 () -> driver.getPropertyInfo(url, new Properties())
         );
     }


### PR DESCRIPTION
Three tests assumed POSIX-style paths and Linux IOException messages, so they always failed on Windows but passed on the Ubuntu-only CI:

  * getTokenAs / getCaCertificateAs build a JDBC URL by appending File.getAbsolutePath() after a "file:" prefix. On Windows the path contains backslashes, which are illegal in URL query components, so URI parsing rejected the URL ("Illegal character in query at index ..."). Normalize to forward slashes before appending.
  * getCaCertificateAsInvalid asserted the exact "(No such file or directory)" suffix produced by Linux's FileNotFoundException; Windows produces a different message and a backslash-form path. Switch to a startsWith assertion on the OS-stable prefix and add a sqlExceptionStartsWith helper to ExceptionAssert.

No production code changes.