### PR TITLE
Add SLO workflow for JDBC workloads

### DIFF
--- a/.github/scripts/build-slo-image.sh
+++ b/.github/scripts/build-slo-image.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'EOF'
+Usage:
+  build-slo-image.sh \
+    --jdbc <path> \
+    --examples <path> \
+    --workload <jdbc|spring-data-jdbc|spring-data-jpa> \
+    --tag <docker-tag> \
+    [--fallback-image <docker-tag>]
+
+Options:
+  --jdbc            Path to the ydb-jdbc-driver checkout to build against.
+  --examples        Path to the ydb-java-examples checkout.
+  --workload        SLO workload module to build.
+  --tag             Docker tag to assign to the built image.
+  --fallback-image  If the initial Docker build fails, tag this image as
+                    --tag and exit successfully.
+EOF
+}
+
+die() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+jdbc_dir=""
+examples_dir=""
+workload=""
+tag=""
+fallback_image=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --jdbc)
+            jdbc_dir="${2:-}"
+            shift 2
+            ;;
+        --examples)
+            examples_dir="${2:-}"
+            shift 2
+            ;;
+        --workload)
+            workload="${2:-}"
+            shift 2
+            ;;
+        --tag)
+            tag="${2:-}"
+            shift 2
+            ;;
+        --fallback-image)
+            fallback_image="${2:-}"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "Unknown argument: $1 (use --help)"
+            ;;
+    esac
+done
+
+if [[ -z "$jdbc_dir" || -z "$examples_dir" || -z "$workload" || -z "$tag" ]]; then
+    usage
+    die "Incomplete argument set"
+fi
+
+case "$workload" in
+    jdbc|spring-data-jdbc|spring-data-jpa)
+        ;;
+    *)
+        die "Unsupported workload: $workload"
+        ;;
+esac
+
+[[ -d "$jdbc_dir" ]] || die "--jdbc does not exist: $jdbc_dir"
+[[ -d "$examples_dir" ]] || die "--examples does not exist: $examples_dir"
+
+jdbc_dir="$(cd "$jdbc_dir" && pwd)"
+examples_dir="$(cd "$examples_dir" && pwd)"
+
+dockerfile="${examples_dir}/slo-workload/${workload}/Dockerfile"
+[[ -f "$dockerfile" ]] || die "Dockerfile not found: $dockerfile"
+
+context_dir="$(mktemp -d)"
+trap 'rm -rf "$context_dir"' EXIT
+
+echo "Assembling build context in $context_dir"
+echo "  ydb-jdbc-driver:  $jdbc_dir"
+echo "  ydb-java-examples: $examples_dir"
+echo "  workload:          $workload"
+echo "  tag:               $tag"
+
+copy_tree() {
+    local src="$1"
+    local dst="$2"
+    mkdir -p "$dst"
+    if cp -al "$src"/. "$dst"/ 2>/dev/null; then
+        return 0
+    fi
+    cp -a "$src"/. "$dst"/
+}
+
+copy_tree "$examples_dir" "$context_dir"
+copy_tree "$jdbc_dir" "$context_dir/ydb-jdbc-driver"
+
+rm -rf "$context_dir/.git" "$context_dir/ydb-jdbc-driver/.git"
+
+for required in \
+    "$context_dir/ydb-jdbc-driver/pom.xml" \
+    "$context_dir/slo-workload/${workload}/Dockerfile"
+do
+    [[ -f "$required" ]] || die "Build context missing required file: $required"
+done
+
+set +e
+docker build \
+    --platform linux/amd64 \
+    -t "$tag" \
+    -f "$dockerfile" \
+    "$context_dir"
+exit_code=$?
+set -e
+
+if [[ $exit_code -eq 0 ]]; then
+    echo "Docker image $tag built successfully"
+    exit 0
+fi
+
+echo "Docker build for $tag failed (exit code $exit_code)" >&2
+
+if [[ -z "$fallback_image" ]]; then
+    die "Docker build failed and --fallback-image is not set"
+fi
+
+echo "Falling back to image $fallback_image, tagging as $tag"
+docker tag "$fallback_image" "$tag"

--- a/.github/workflows/slo.yaml
+++ b/.github/workflows/slo.yaml
@@ -1,0 +1,168 @@
+name: SLO
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+
+jobs:
+  ydb-slo-action:
+    if: contains(github.event.pull_request.labels.*.name, 'SLO')
+
+    name: Run YDB SLO Tests
+    runs-on: large-runner-java-sdk
+
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        workload:
+          - name: java-jdbc-kv
+            module: jdbc
+            command: ""
+          - name: java-spring-data-jdbc-kv
+            module: spring-data-jdbc
+            command: ""
+          - name: java-spring-data-jpa-kv
+            module: spring-data-jpa
+            command: ""
+
+    concurrency:
+      group: slo-${{ github.ref }}-${{ matrix.workload.name }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Install dependencies
+        run: |
+          set -euxo pipefail
+          YQ_VERSION=v4.48.2
+          BUILDX_VERSION=0.30.1
+          COMPOSE_VERSION=2.40.3
+
+          sudo curl -fLo /usr/local/bin/yq \
+            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          sudo chmod +x /usr/local/bin/yq
+
+          sudo mkdir -p /usr/local/lib/docker/cli-plugins
+
+          sudo curl -fLo /usr/local/lib/docker/cli-plugins/docker-buildx \
+            "https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-amd64"
+          sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx
+
+          sudo curl -fLo /usr/local/lib/docker/cli-plugins/docker-compose \
+            "https://github.com/docker/compose/releases/download/v${COMPOSE_VERSION}/docker-compose-linux-x86_64"
+          sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+
+          yq --version
+          docker --version
+          docker buildx version
+          docker compose version
+
+      - name: Checkout current JDBC driver version
+        uses: actions/checkout@v5
+        with:
+          path: jdbc-current
+          fetch-depth: 0
+
+      - name: Determine baseline commit
+        id: baseline
+        working-directory: jdbc-current
+        run: |
+          set -euo pipefail
+          BASELINE=$(git merge-base HEAD origin/master)
+          echo "sha=${BASELINE}" >> "$GITHUB_OUTPUT"
+
+          if git merge-base --is-ancestor "${BASELINE}" origin/master && \
+             [ "$(git rev-parse origin/master)" = "${BASELINE}" ]; then
+            BASELINE_REF="master"
+          else
+            BRANCH=$(git branch -r --contains "${BASELINE}" | grep -v HEAD | head -1 | sed 's|.*/||' || echo "")
+            if [ -n "${BRANCH}" ]; then
+              BASELINE_REF="${BRANCH}@${BASELINE:0:7}"
+            else
+              BASELINE_REF="${BASELINE:0:7}"
+            fi
+          fi
+          echo "ref=${BASELINE_REF}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout baseline JDBC driver version
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.baseline.outputs.sha }}
+          path: jdbc-baseline
+          fetch-depth: 1
+
+      - name: Checkout ydb-java-examples
+        uses: actions/checkout@v5
+        with:
+          repository: ydb-platform/ydb-java-examples
+          ref: master
+          path: examples
+
+      - name: Build current workload image
+        run: |
+          set -euxo pipefail
+          chmod +x jdbc-current/.github/scripts/build-slo-image.sh
+          jdbc-current/.github/scripts/build-slo-image.sh \
+            --jdbc     jdbc-current \
+            --examples examples \
+            --workload ${{ matrix.workload.module }} \
+            --tag      ydb-app-current-${{ matrix.workload.module }}
+
+      - name: Build baseline workload image
+        run: |
+          set -euxo pipefail
+          # Reuse the build script from the current checkout — it doesn't
+          # depend on JDBC driver contents, only on the layout it produces.
+          jdbc-current/.github/scripts/build-slo-image.sh \
+            --jdbc     jdbc-baseline \
+            --examples examples \
+            --workload ${{ matrix.workload.module }} \
+            --tag      ydb-app-baseline-${{ matrix.workload.module }} \
+            --fallback-image ydb-app-current-${{ matrix.workload.module }}
+
+      - name: Run SLO Tests
+        uses: ydb-platform/ydb-slo-action/init@v2
+        timeout-minutes: 30
+        with:
+          github_issue: ${{ github.event.pull_request.number }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workload_name: ${{ matrix.workload.name }}
+          workload_duration: "600"
+          workload_current_ref: ${{ github.head_ref || github.ref_name }}
+          workload_current_image: ydb-app-current-${{ matrix.workload.module }}
+          workload_current_command: ${{ matrix.workload.command }} --read-rps 1000 --write-rps 100
+          workload_baseline_ref: ${{ steps.baseline.outputs.ref }}
+          workload_baseline_image: ydb-app-baseline-${{ matrix.workload.module }}
+          workload_baseline_command: ${{ matrix.workload.command }} --read-rps 1000 --write-rps 100
+
+  publish-slo-report:
+    needs: ydb-slo-action
+    if: ${{ !cancelled() && needs.ydb-slo-action.result != 'skipped' }}
+
+    name: Publish YDB SLO Report
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
+
+    steps:
+      - name: Publish YDB SLO Report
+        uses: ydb-platform/ydb-slo-action/report@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_run_id: ${{ github.run_id }}
+          github_issue: ${{ github.event.pull_request.number }}
+
+      - name: Remove SLO label from PR
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh pr edit "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --remove-label SLO


### PR DESCRIPTION
## Summary
- Add an SLO workflow triggered by the `SLO` PR label.
- Build current and baseline workload images against source-built ydb-jdbc-driver checkouts.
- Run ydb-slo-action for plain JDBC, Spring Data JDBC, and Spring Data JPA/Hibernate 6 workloads.

## Test plan
- `bash -n .github/scripts/build-slo-image.sh`
- YAML parsed locally with Ruby `YAML.load_file`

## Depends on
- ydb-platform/ydb-java-examples#64

## Merge order
Merge after ydb-platform/ydb-java-examples#64 lands on `master`.

Made with [Cursor](https://cursor.com)