### PR TITLE
Move SLO report publishing to workflow_run

### DIFF
--- a/.github/workflows/slo-report.yml
+++ b/.github/workflows/slo-report.yml
@@ -1,0 +1,40 @@
+name: SLO Report
+
+on:
+  workflow_run:
+    workflows: ["SLO"]
+    types:
+      - completed
+
+jobs:
+  publish-slo-report:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    name: Publish YDB SLO Report
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Publish YDB SLO Report
+        uses: ydb-platform/ydb-slo-action/report@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_run_id: ${{ github.event.workflow_run.id }}
+
+  remove-slo-label:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    name: Remove SLO Label
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Remove SLO label from PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRS: ${{ toJSON(github.event.workflow_run.pull_requests) }}
+          REPO: ${{ github.event.workflow_run.repository.full_name }}
+        run: |
+          set -euo pipefail
+          PR=$(jq -r '.[0].number' <<<"$PRS")
+          gh pr edit "$PR" --repo "$REPO" --remove-label SLO

--- a/.github/workflows/slo.yaml
+++ b/.github/workflows/slo.yaml
@@ -136,33 +136,3 @@ jobs:
           workload_baseline_ref: ${{ steps.baseline.outputs.ref }}
           workload_baseline_image: ydb-app-baseline-${{ matrix.workload.module }}
           workload_baseline_command: ${{ matrix.workload.command }} --read-rps 1000 --write-rps 100
-
-  publish-slo-report:
-    needs: ydb-slo-action
-    if: ${{ !cancelled() && needs.ydb-slo-action.result != 'skipped' }}
-
-    name: Publish YDB SLO Report
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-      pull-requests: write
-      checks: write
-
-    steps:
-      - name: Publish YDB SLO Report
-        uses: ydb-platform/ydb-slo-action/report@v2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          github_run_id: ${{ github.run_id }}
-          github_issue: ${{ github.event.pull_request.number }}
-
-      - name: Remove SLO label from PR
-        if: github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          gh pr edit "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" \
-            --remove-label SLO

--- a/.github/workflows/slo.yaml
+++ b/.github/workflows/slo.yaml
@@ -9,7 +9,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'SLO')
 
     name: Run YDB SLO Tests
-    runs-on: large-runner-java-sdk
+    runs-on: large-runner-jdbc-driver
 
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Split SLO report publishing into a separate `slo-report.yml` workflow triggered by `workflow_run`, matching [ydb-dotnet-sdk](https://github.com/ydb-platform/ydb-dotnet-sdk/tree/main/.github/workflows).
- Remove inline `publish-slo-report` job from `slo.yaml` so fork PRs can receive SLO comments after this workflow file is on `master`.

## Test plan
- [x] Add `SLO` label to this PR to run workloads
- [ ] Verify SLO tests complete and artifacts are uploaded
- [ ] Merge to `master`, then confirm `SLO Report` workflow posts a comment (workflow_run only runs from default branch)


Made with [Cursor](https://cursor.com)